### PR TITLE
Place kv_namespaces correctly in wrangler template.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,13 +273,14 @@ async function doExecute(env: Env) {
 	const results = await fetchNordigenTransactions(token, env.NORDIGEN_ACCOUNT_ID, dateFrom, dateTo);
 
 	console.log("booked", results.transactions.booked);
-	console.log("pending", results.transactions.pending);
 
 	// store transactions in DB
 	await storeBankTransactions(env.DB, results.transactions.booked);
 
 	// read transaction matchers from KV
 	const transactionMatchers = await fetchTransactionMatchers(env.KV);
+
+	console.log("matchers", transactionMatchers);
 
 	// create map of matching transactions
 	const matched = new Map<string, BankTransaction>();

--- a/wrangler.toml.template
+++ b/wrangler.toml.template
@@ -2,6 +2,10 @@ name = "bankman"
 main = "src/index.ts"
 compatibility_date = "2022-12-20"
 
+kv_namespaces = [
+    { binding = "KV", id = "$KV_ID" }
+]
+
 [triggers]
 crons = [ "0 * * * *" ]
 
@@ -9,7 +13,3 @@ crons = [ "0 * * * *" ]
 binding = "DB"
 database_name = "bankmandb"
 database_id = "$DATABASE_ID"
-
-kv_namespaces = [
-    { binding = "KV", id = "$KV_ID" }
-]


### PR DESCRIPTION
`kv_namespaces` was in the wrong place within wrangler template, leading to field being ignored by wrangler cli.

We should release 0.2.0 after this.