### PR TITLE
feat: Add git-cliff for changelog automation and add teardown script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## Unreleased
+
+### Bug Fixes
+
+-  Place kv_namespaces correctly in wrangler template. (#2) ([b73b9cf4](https://github.com/meltway-labs/bankman/commit/b73b9cf491481cc0a02f96f385cfabe979774170))
+
+
+## 0.1.0 (2022/12/27)
+
+### Bug Fixes
+
+-  Fix devcontainer env.
+ ([7ce6590c](https://github.com/meltway-labs/bankman/commit/7ce6590ccb32975175f13aebb90b07742f8a3481))
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Getting started
 
 To run the project locally:
-    ```shell
-    npm i
-    npm start
-    ```
+```shell
+npm i
+npm start
+```
 
 You also need to run the database migrations:
 ```shell

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+[changelog]
+header = ""
+
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version %}\
+    ## {{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%Y/%m/%d") }})
+{% else %}\
+    ## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits
+    | filter(attribute="scope")
+    | sort(attribute="scope") %}
+        - **{{commit.scope}}:** {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=8, end="") }}](https://github.com/meltway-labs/bankman/commit/{{ commit.id }}))
+        {%- if commit.breaking %}
+        {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
+        {%- endif -%}
+    {%- endfor %}
+    {% for commit in commits %}
+        {%- if commit.scope -%}
+        {% else -%}
+            -  {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=8, end="") }}](https://github.com/meltway-labs/bankman/commit/{{ commit.id }}))
+            {% if commit.breaking -%}
+            {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
+            {% endif -%}
+        {% endif -%}
+    {% endfor -%}
+    {% raw %}\n{% endraw %}\
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = []
+commit_parsers = [
+    { message = "^[Ff]eat(ure)?", group = "Features" },
+    { message = "^[Ff]ix", group = "Bug Fixes" },
+    { message = "^[Dd]oc(s)?(umentation)?", group = "Documentation" },
+    { message = "^[Pp]erf(ormance)?", group = "Performance" },
+    { message = "^[Rr]efactor", group = "Refactor" },
+    { message = "^[Ss]tyle", group = "Styling" },
+    { message = "^[Tt]est(s)?", group = "Testing" },
+    { message = "^[Cc]hore\\(ci\\): Bump version to", skip = true },
+    { message = "^[Cc]hore", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = ""
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+# limit_commits = 42

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@cloudflare/workers-types": "^4.20221111.1",
         "better-sqlite3": "^7.6.2",
         "typescript": "^4.9.4",
-        "wrangler": "2.6.2"
+        "wrangler": "^2.6.2"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20221111.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20221111.1.tgz",
-      "integrity": "sha512-BNV2wN8V6Zduvo7UzxcdjBbLQ906D2KhS804PDufLgx/sanGJCHVJMOIaLvS/b61JKtot1U7P/l1fjrjZ7/E3A==",
+      "version": "4.20230115.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20230115.0.tgz",
+      "integrity": "sha512-GPJEiO8AFN+jUpA+DHJ1qdVmk4s/hq8JYKjOV/+U7avGquQbVnj905+Kg6uAEfrq16muwmRKl+XJGqsvlBlDNg==",
       "dev": true
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
@@ -51,6 +51,358 @@
         "esbuild": "*"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.3.tgz",
+      "integrity": "sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.3.tgz",
+      "integrity": "sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.3.tgz",
+      "integrity": "sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
+      "integrity": "sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.3.tgz",
+      "integrity": "sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.3.tgz",
+      "integrity": "sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.3.tgz",
+      "integrity": "sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.3.tgz",
+      "integrity": "sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.3.tgz",
+      "integrity": "sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.3.tgz",
+      "integrity": "sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.3.tgz",
+      "integrity": "sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.3.tgz",
+      "integrity": "sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.3.tgz",
+      "integrity": "sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.3.tgz",
+      "integrity": "sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.3.tgz",
+      "integrity": "sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.3.tgz",
+      "integrity": "sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.3.tgz",
+      "integrity": "sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.3.tgz",
+      "integrity": "sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.3.tgz",
+      "integrity": "sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.3.tgz",
+      "integrity": "sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.3.tgz",
+      "integrity": "sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -58,13 +410,13 @@
       "dev": true
     },
     "node_modules/@miniflare/cache": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.10.0.tgz",
-      "integrity": "sha512-nzEqFVPnD7Yf0HMDv7gCPpf4NSXfjhc+zg3gSwUS4Dad5bWV10B1ujTZW6HxQulW3CBHIg616mTjXIiaimVuEQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cache/-/cache-2.11.0.tgz",
+      "integrity": "sha512-L/kc9AzidPwFuk2fwHpAEePi0kNBk6FWUq3ln+9beRCDrPEpfVrDRFpNleF1NFZz5//oeVMuo8F0IVUQGzR7+Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "http-cache-semantics": "^4.1.0",
         "undici": "5.9.1"
       },
@@ -73,12 +425,12 @@
       }
     },
     "node_modules/@miniflare/cli-parser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.10.0.tgz",
-      "integrity": "sha512-NAiCtqlHTUKCmV+Jl9af+ixGmMhiGhIyIfr/vCdbismNEBxEsrQGg3sQYTNfvCkdHtODurQqayQreFq21OuEow==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/cli-parser/-/cli-parser-2.11.0.tgz",
+      "integrity": "sha512-JUmyRzEGAS6CouvXJwBh8p44onfw3KRpfq5JGXEuHModOGjTp6li7PQyCTNPV2Hv/7StAXWnTFGXeAqyDHuTig==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "kleur": "^4.1.4"
       },
       "engines": {
@@ -86,15 +438,15 @@
       }
     },
     "node_modules/@miniflare/core": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.10.0.tgz",
-      "integrity": "sha512-Jx1M5oXQua0jzsJVdZSq07baVRmGC/6JkglrPQGAlZ7gQ1sunVZzq9fjxFqj0bqfEuYS0Wy6+lvK4rOAHISIjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-UFMFiCG0co36VpZkgFrSBnrxo71uf1x+cjlzzJi3khmMyDlnLu4RuIQsAqvKbYom6fi3G9Q8lTgM7JuOXFyjhw==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/watcher": "2.10.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/watcher": "2.11.0",
         "busboy": "^1.6.0",
         "dotenv": "^10.0.0",
         "kleur": "^4.1.4",
@@ -107,27 +459,27 @@
       }
     },
     "node_modules/@miniflare/d1": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.10.0.tgz",
-      "integrity": "sha512-mOYZSmpTthH0tmFTQ+O9G0Q+iDAd7oiUtoIBianlKa9QiqYAoO7EBUPy6kUgDHXapOcN5Ri1u3J5UTpxXvw3qg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/d1/-/d1-2.11.0.tgz",
+      "integrity": "sha512-aDdBVQZ2C0Zs3+Y9ZbRctmuQxozPfpumwJ/6NG6fBadANvune/hW7ddEoxyteIEU9W3IgzVj8s4by4VvasX90A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/durable-objects": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.10.0.tgz",
-      "integrity": "sha512-gU45f52gveFtCasm0ixYnt0mHI1lHrPomtmF+89oZGKBzOqUfO5diDs6wmoRSnovOWZCwtmwQGRoorAQN7AmoA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/durable-objects/-/durable-objects-2.11.0.tgz",
+      "integrity": "sha512-0cKJaMgraTEU1b4kqK8cjD2oTeOjA6QU3Y+lWiZT/k1PMHZULovrSFnjii7qZ8npf4VHSIN6XYPxhyxRyEM65Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -135,13 +487,13 @@
       }
     },
     "node_modules/@miniflare/html-rewriter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.10.0.tgz",
-      "integrity": "sha512-hCdG99L8+Ros4dn3B5H37PlQPBH0859EoRslzNTd4jzGIkwdiawpJvrvesL8056GjbUjeJN1zh7OPBRuMgyGLw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/html-rewriter/-/html-rewriter-2.11.0.tgz",
+      "integrity": "sha512-olTqmuYTHnoTNtiA0vjQ/ixRfbwgPzDrAUbtXDCYW45VFbHfDVJrJGZX3Jg0HpSlxy86Zclle1SUxGbVDzxsBg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "html-rewriter-wasm": "^0.4.1",
         "undici": "5.9.1"
       },
@@ -150,14 +502,14 @@
       }
     },
     "node_modules/@miniflare/http-server": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.10.0.tgz",
-      "integrity": "sha512-cm6hwkONucll93yoY8dteMp//Knvmb7n6zAgeHrtuNYKn//lAL6bRY//VLTttrMmfWxZFi1C7WpOeCv8Mn6/ug==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/http-server/-/http-server-2.11.0.tgz",
+      "integrity": "sha512-sMLcrDFzqqAvnQmAUH0hRTo8sBjW79VZYfnIH5FAGSGcKX6kdAGs9RStdYZ4CftQCBAEQScX0KBsMx5FwJRe9Q==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "selfsigned": "^2.0.0",
         "undici": "5.9.1",
@@ -169,36 +521,36 @@
       }
     },
     "node_modules/@miniflare/kv": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.10.0.tgz",
-      "integrity": "sha512-3+u1lO77FnlS0lQ6b1VgM1E/ZgQ/zy/FU+SdBG5LUOIiv3x522VYHOApeJLnSEo0KtZUB22Ni0fWQM6DgpaREg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/kv/-/kv-2.11.0.tgz",
+      "integrity": "sha512-3m9dL2HBBN170V1JvwjjucR5zl4G3mlcsV6C1E7A2wLl2Z2TWvIx/tSY9hrhkD96dFnejwJ9qmPMbXMMuynhjg==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/queues": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.10.0.tgz",
-      "integrity": "sha512-WKdO6qI9rfS96KlCjazzPFf+qj6DPov4vONyf18+jzbRjRJh/xwWSk1/1h5A+gDPwVNG8TsNRPh9DW5OKBGNjw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/queues/-/queues-2.11.0.tgz",
+      "integrity": "sha512-fLHjdrNLKhn0LZM/aii/9GsAttFd+lWlGzK8HOg1R0vhfKBwEub4zntjMmOfFbDm1ntc21tdMK7n3ldUphwh5w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.7"
       }
     },
     "node_modules/@miniflare/r2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.10.0.tgz",
-      "integrity": "sha512-uC1CCWbwM1t8DdpZgrveg6+CkZLfTq+wUMqs20BC5rCT8u8UyRv6ZVRQ7pTPiswLyt1oYDTXsZJK7tjV0U0zew==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/r2/-/r2-2.11.0.tgz",
+      "integrity": "sha512-MKuyJ/gGNsK3eWbGdygvozqcyaZhM3C6NGHvoaZwH503dwN569j5DpatTWiHGFeDeSu64VqcIsGehz05GDUaag==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1"
       },
       "engines": {
@@ -206,25 +558,25 @@
       }
     },
     "node_modules/@miniflare/runner-vm": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.10.0.tgz",
-      "integrity": "sha512-oTsHitQdQ1B1kT3G/6n9AEXsMd/sT1D8tLGzc7Xr79ZrxYxwRO0ATF3cdkxk4dUjUqg/RUqvOJV4YjJGyqvctg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/runner-vm/-/runner-vm-2.11.0.tgz",
+      "integrity": "sha512-bkVSuvCf5+VylqN8lTiLxIYqYcKFbl+BywZGwGQndPC/3wh42J00mM0jw4hRbvXgwuBhlUyCVpEXtYlftFFT/g==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/scheduler": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.10.0.tgz",
-      "integrity": "sha512-eGt2cZFE/yo585nT8xINQwdbTotZfeRIh6FUWmZkbva1i5SW0zTiOojr5a95vAGBF3TzwWGsUuzJpLhBB69a/g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/scheduler/-/scheduler-2.11.0.tgz",
+      "integrity": "sha512-DPdzINhdWeS99eIicGoluMsD4pLTTAWNQbgCv3CTwgdKA3dxdvMSCkNqZzQLiALzvk9+rSfj46FlH++HE7o7/w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "cron-schedule": "^3.0.4"
       },
       "engines": {
@@ -232,9 +584,9 @@
       }
     },
     "node_modules/@miniflare/shared": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.10.0.tgz",
-      "integrity": "sha512-GDSweEhJ3nNtStGm6taZGUNytM0QTQ/sjZSedAKyF1/aHRaZUcD9cuKAMgIbSpKfvgGdLMNS7Bhd8jb249TO7g==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/shared/-/shared-2.11.0.tgz",
+      "integrity": "sha512-fWMqq3ZkWAg+k7CnyzMV/rZHugwn+/JxvVzCxrtvxzwotTN547THlOxgZe8JAP23U9BiTxOfpTfnLvFEjAmegw==",
       "dev": true,
       "dependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -247,64 +599,64 @@
       }
     },
     "node_modules/@miniflare/sites": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.10.0.tgz",
-      "integrity": "sha512-1NVAT6+JS2OubL+pOOR5E/6MMddxQHWMi/yIDSumyyfXmj7Sm7n5dE1FvNPetggMP4f8+AjoyT9AYvdd1wkspQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/sites/-/sites-2.11.0.tgz",
+      "integrity": "sha512-qbefKdWZUJgsdLf+kCw03sn3h/92LZgJAbkOpP6bCrfWkXlJ37EQXO4KWdhn4Ghc7A6GwU1s1I/mdB64B3AewQ==",
       "dev": true,
       "dependencies": {
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-file": "2.10.0"
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-file": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-file": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.10.0.tgz",
-      "integrity": "sha512-K/cRIWiTl4+Z+VO6tl4VfuYXA3NLJgvGPV+BCRYD7uTKuPYHqDMErtD1BI1I7nc3WJhwIXfzJrAR3XXhSKKWQQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-file/-/storage-file-2.11.0.tgz",
+      "integrity": "sha512-beWF/lTX74x7AiaSB+xQxywPSNdhtEKvqDkRui8eOJ5kqN2o4UaleLKQGgqmCw3WyHRIsckV7If1qpbNiLtWMw==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0"
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/storage-memory": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.10.0.tgz",
-      "integrity": "sha512-ZATU+qZtJ9yG0umgTrOEUi9SU//YyDb8nYXMgqT4JHODYA3RTz1SyyiQSOOz589upJPdu1LN+0j8W24WGRwwxQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/storage-memory/-/storage-memory-2.11.0.tgz",
+      "integrity": "sha512-s0AhPww7fq/Jz80NbPb+ffhcVRKnfPi7H1dHTRTre2Ud23EVJjAWl2gat42x8NOT/Fu3/o/7A72DWQQJqfO98A==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/watcher": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.10.0.tgz",
-      "integrity": "sha512-X9CFYYyszfSYDzs07KhbWC2i08Dpyh3D60fPonYZcoZAfa5h9eATHUdRGvNCdax7awYp4b8bvU8upAI//OPlMg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/watcher/-/watcher-2.11.0.tgz",
+      "integrity": "sha512-RUfjz2iYcsQXLcGySemJl98CJ2iierbWsPGWZhIVZI+NNhROkEy77g/Q+lvP2ATwexG3/dUSfdJ3P8aH+sI4Ig==",
       "dev": true,
       "dependencies": {
-        "@miniflare/shared": "2.10.0"
+        "@miniflare/shared": "2.11.0"
       },
       "engines": {
         "node": ">=16.13"
       }
     },
     "node_modules/@miniflare/web-sockets": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.10.0.tgz",
-      "integrity": "sha512-W+PrapdQqNEEFeD+amENgPQWcETGDp7OEh6JAoSzCRhHA0OoMe8DG0xb5a5+2FjGW/J7FFKsv84wkURpmFT4dQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@miniflare/web-sockets/-/web-sockets-2.11.0.tgz",
+      "integrity": "sha512-NC8RKrmxrO0hZmwpzn5g4hPGA2VblnFTIBobmWoxuK95eW49zfs7dtE/PyFs+blsGv3CjTIjHVSQ782K+C6HFA==",
       "dev": true,
       "dependencies": {
-        "@miniflare/core": "2.10.0",
-        "@miniflare/shared": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/shared": "2.11.0",
         "undici": "5.9.1",
         "ws": "^8.2.2"
       },
@@ -322,9 +674,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "node_modules/@types/stack-trace": {
@@ -589,9 +941,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.51.tgz",
-      "integrity": "sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.3.tgz",
+      "integrity": "sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -601,346 +953,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.51",
-        "esbuild-android-arm64": "0.14.51",
-        "esbuild-darwin-64": "0.14.51",
-        "esbuild-darwin-arm64": "0.14.51",
-        "esbuild-freebsd-64": "0.14.51",
-        "esbuild-freebsd-arm64": "0.14.51",
-        "esbuild-linux-32": "0.14.51",
-        "esbuild-linux-64": "0.14.51",
-        "esbuild-linux-arm": "0.14.51",
-        "esbuild-linux-arm64": "0.14.51",
-        "esbuild-linux-mips64le": "0.14.51",
-        "esbuild-linux-ppc64le": "0.14.51",
-        "esbuild-linux-riscv64": "0.14.51",
-        "esbuild-linux-s390x": "0.14.51",
-        "esbuild-netbsd-64": "0.14.51",
-        "esbuild-openbsd-64": "0.14.51",
-        "esbuild-sunos-64": "0.14.51",
-        "esbuild-windows-32": "0.14.51",
-        "esbuild-windows-64": "0.14.51",
-        "esbuild-windows-arm64": "0.14.51"
-      }
-    },
-    "node_modules/esbuild-android-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.51.tgz",
-      "integrity": "sha512-6FOuKTHnC86dtrKDmdSj2CkcKF8PnqkaIXqvgydqfJmqBazCPdw+relrMlhGjkvVdiiGV70rpdnyFmA65ekBCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.51.tgz",
-      "integrity": "sha512-vBtp//5VVkZWmYYvHsqBRCMMi1MzKuMIn5XDScmnykMTu9+TD9v0NMEDqQxvtFToeYmojdo5UCV2vzMQWJcJ4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.51.tgz",
-      "integrity": "sha512-YFmXPIOvuagDcwCejMRtCDjgPfnDu+bNeh5FU2Ryi68ADDVlWEpbtpAbrtf/lvFTWPexbgyKgzppNgsmLPr8PA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.51.tgz",
-      "integrity": "sha512-juYD0QnSKwAMfzwKdIF6YbueXzS6N7y4GXPDeDkApz/1RzlT42mvX9jgNmyOlWKN7YzQAYbcUEJmZJYQGdf2ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.51.tgz",
-      "integrity": "sha512-cLEI/aXjb6vo5O2Y8rvVSQ7smgLldwYY5xMxqh/dQGfWO+R1NJOFsiax3IS4Ng300SVp7Gz3czxT6d6qf2cw0g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.51.tgz",
-      "integrity": "sha512-TcWVw/rCL2F+jUgRkgLa3qltd5gzKjIMGhkVybkjk6PJadYInPtgtUBp1/hG+mxyigaT7ib+od1Xb84b+L+1Mg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.51.tgz",
-      "integrity": "sha512-RFqpyC5ChyWrjx8Xj2K0EC1aN0A37H6OJfmUXIASEqJoHcntuV3j2Efr9RNmUhMfNE6yEj2VpYuDteZLGDMr0w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.51.tgz",
-      "integrity": "sha512-dxjhrqo5i7Rq6DXwz5v+MEHVs9VNFItJmHBe1CxROWNf4miOGoQhqSG8StStbDkQ1Mtobg6ng+4fwByOhoQoeA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.51.tgz",
-      "integrity": "sha512-LsJynDxYF6Neg7ZC7748yweCDD+N8ByCv22/7IAZglIEniEkqdF4HCaa49JNDLw1UQGlYuhOB8ZT/MmcSWzcWg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.51.tgz",
-      "integrity": "sha512-D9rFxGutoqQX3xJPxqd6o+kvYKeIbM0ifW2y0bgKk5HPgQQOo2k9/2Vpto3ybGYaFPCE5qTGtqQta9PoP6ZEzw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.51.tgz",
-      "integrity": "sha512-vS54wQjy4IinLSlb5EIlLoln8buh1yDgliP4CuEHumrPk4PvvP4kTRIG4SzMXm6t19N0rIfT4bNdAxzJLg2k6A==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.51.tgz",
-      "integrity": "sha512-xcdd62Y3VfGoyphNP/aIV9LP+RzFw5M5Z7ja+zdpQHHvokJM7d0rlDRMN+iSSwvUymQkqZO+G/xjb4/75du8BQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.51.tgz",
-      "integrity": "sha512-syXHGak9wkAnFz0gMmRBoy44JV0rp4kVCEA36P5MCeZcxFq8+fllBC2t6sKI23w3qd8Vwo9pTADCgjTSf3L3rA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.51.tgz",
-      "integrity": "sha512-kFAJY3dv+Wq8o28K/C7xkZk/X34rgTwhknSsElIqoEo8armCOjMJ6NsMxm48KaWY2h2RUYGtQmr+RGuUPKBhyw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.51.tgz",
-      "integrity": "sha512-ZZBI7qrR1FevdPBVHz/1GSk1x5GDL/iy42Zy8+neEm/HA7ma+hH/bwPEjeHXKWUDvM36CZpSL/fn1/y9/Hb+1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.51.tgz",
-      "integrity": "sha512-7R1/p39M+LSVQVgDVlcY1KKm6kFKjERSX1lipMG51NPcspJD1tmiZSmmBXoY5jhHIu6JL1QkFDTx94gMYK6vfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.51.tgz",
-      "integrity": "sha512-HoHaCswHxLEYN8eBTtyO0bFEWvA3Kdb++hSQ/lLG7TyKF69TeSG0RNoBRAs45x/oCeWaTDntEZlYwAfQlhEtJA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.51.tgz",
-      "integrity": "sha512-4rtwSAM35A07CBt1/X8RWieDj3ZUHQqUOaEo5ZBs69rt5WAFjP4aqCIobdqOy4FdhYw1yF8Z0xFBTyc9lgPtEg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.51.tgz",
-      "integrity": "sha512-HoN/5HGRXJpWODprGCgKbdMvrC3A2gqvzewu2eECRw2sYxOUoh2TV1tS+G7bHNapPGI79woQJGV6pFH7GH7qnA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.51",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.51.tgz",
-      "integrity": "sha512-JQDqPjuOH7o+BsKMSddMfmVJXrnYZxXDHsoLHc0xgmAZkOOCflRmC43q31pk79F9xuyWY45jDBPolb5ZgGOf9g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
+        "@esbuild/android-arm": "0.16.3",
+        "@esbuild/android-arm64": "0.16.3",
+        "@esbuild/android-x64": "0.16.3",
+        "@esbuild/darwin-arm64": "0.16.3",
+        "@esbuild/darwin-x64": "0.16.3",
+        "@esbuild/freebsd-arm64": "0.16.3",
+        "@esbuild/freebsd-x64": "0.16.3",
+        "@esbuild/linux-arm": "0.16.3",
+        "@esbuild/linux-arm64": "0.16.3",
+        "@esbuild/linux-ia32": "0.16.3",
+        "@esbuild/linux-loong64": "0.16.3",
+        "@esbuild/linux-mips64el": "0.16.3",
+        "@esbuild/linux-ppc64": "0.16.3",
+        "@esbuild/linux-riscv64": "0.16.3",
+        "@esbuild/linux-s390x": "0.16.3",
+        "@esbuild/linux-x64": "0.16.3",
+        "@esbuild/netbsd-x64": "0.16.3",
+        "@esbuild/openbsd-x64": "0.16.3",
+        "@esbuild/sunos-x64": "0.16.3",
+        "@esbuild/win32-arm64": "0.16.3",
+        "@esbuild/win32-ia32": "0.16.3",
+        "@esbuild/win32-x64": "0.16.3"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1068,9 +1102,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/human-signals": {
@@ -1247,28 +1281,28 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.10.0.tgz",
-      "integrity": "sha512-WPveqChVDdmDGv+wFqXjFqEZlZ5/aBlAKX37h/e4TAjl2XsK5nPfQATP8jZXwNDEC5iE29bYZymOqeZkp+t7OA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-2.11.0.tgz",
+      "integrity": "sha512-QA18I1VQXdCo4nBtPJUcUDxW8c9xbc5ex5F61jwhkGVOISSnYdEheolESmjr8MYk28xwi0XD1ozS4rLaTONd+w==",
       "dev": true,
       "dependencies": {
-        "@miniflare/cache": "2.10.0",
-        "@miniflare/cli-parser": "2.10.0",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
-        "@miniflare/html-rewriter": "2.10.0",
-        "@miniflare/http-server": "2.10.0",
-        "@miniflare/kv": "2.10.0",
-        "@miniflare/queues": "2.10.0",
-        "@miniflare/r2": "2.10.0",
-        "@miniflare/runner-vm": "2.10.0",
-        "@miniflare/scheduler": "2.10.0",
-        "@miniflare/shared": "2.10.0",
-        "@miniflare/sites": "2.10.0",
-        "@miniflare/storage-file": "2.10.0",
-        "@miniflare/storage-memory": "2.10.0",
-        "@miniflare/web-sockets": "2.10.0",
+        "@miniflare/cache": "2.11.0",
+        "@miniflare/cli-parser": "2.11.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
+        "@miniflare/html-rewriter": "2.11.0",
+        "@miniflare/http-server": "2.11.0",
+        "@miniflare/kv": "2.11.0",
+        "@miniflare/queues": "2.11.0",
+        "@miniflare/r2": "2.11.0",
+        "@miniflare/runner-vm": "2.11.0",
+        "@miniflare/scheduler": "2.11.0",
+        "@miniflare/shared": "2.11.0",
+        "@miniflare/sites": "2.11.0",
+        "@miniflare/storage-file": "2.11.0",
+        "@miniflare/storage-memory": "2.11.0",
+        "@miniflare/web-sockets": "2.11.0",
         "kleur": "^4.1.4",
         "semiver": "^1.1.0",
         "source-map-support": "^0.5.20",
@@ -1281,7 +1315,7 @@
         "node": ">=16.13"
       },
       "peerDependencies": {
-        "@miniflare/storage-redis": "2.10.0",
+        "@miniflare/storage-redis": "2.11.0",
         "cron-schedule": "^3.0.4",
         "ioredis": "^4.27.9"
       },
@@ -1298,9 +1332,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1340,9 +1374,9 @@
       "dev": true
     },
     "node_modules/node-abi": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.30.0.tgz",
-      "integrity": "sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==",
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
+      "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
       "dev": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -1842,9 +1876,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1903,21 +1937,21 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.6.2.tgz",
-      "integrity": "sha512-+in4oEQXDs6+vE+1c6niBd3IrW1DMRTbauR6G0u3TpD6UaXOLwLdBxRLEbN3m82dN+WNm7l1MbFZrKc/TnWjhw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.9.1.tgz",
+      "integrity": "sha512-tD0DJnUXQe5rd9XyVT4fd7o3N0HGGv70Uz9wAdVUl+R109sOBGfitLUxEx9z7tXOxaigR1X5R/o80yVDBlNr6A==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
-        "@miniflare/core": "2.10.0",
-        "@miniflare/d1": "2.10.0",
-        "@miniflare/durable-objects": "2.10.0",
+        "@miniflare/core": "2.11.0",
+        "@miniflare/d1": "2.11.0",
+        "@miniflare/durable-objects": "2.11.0",
         "blake3-wasm": "^2.1.5",
         "chokidar": "^3.5.3",
-        "esbuild": "0.14.51",
-        "miniflare": "2.10.0",
+        "esbuild": "0.16.3",
+        "miniflare": "2.11.0",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
         "selfsigned": "^2.0.1",
@@ -1942,16 +1976,16 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
     "@cloudflare/workers-types": "^4.20221111.1",
     "better-sqlite3": "^7.6.2",
     "typescript": "^4.9.4",
-    "wrangler": "2.6.2"
+    "wrangler": "^2.6.2"
   },
   "private": true,
   "scripts": {
     "bootstrap": "./scripts/bootstrap.sh",
     "deploy": "wrangler publish --name bankman",
-    "start": "wrangler dev --local"
+    "start": "wrangler dev --local",
+    "teardown": "./scripts/teardown.sh"
   }
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,13 +12,7 @@ check_command tr
 check_command grep
 check_command awk
 
-if ! npm exec --no -- wrangler --version &> /dev/null
-then
-    # shellcheck disable=SC2016
-    print_error "wrangler could not be found. Did you run \`npm install\` ?"
-    print_error "Exiting."
-    exit 1
-fi
+check_wrangler
 
 cp wrangler.toml.template wrangler.toml
 print_info "> Creating KV namespace"
@@ -28,12 +22,12 @@ KV_ID=$(npx wrangler kv:namespace list | jq -r '.[] | select(.title == "bankman-
 export KV_ID
 
 print_info "> Storing notify patterns in KV"
-npx wrangler kv:key --namespace-id $KV_ID put 'transaction-matchers' "$(cat .notify-patterns.json | jq -c .)"
+npx wrangler kv:key --namespace-id "$KV_ID" put 'transaction-matchers' "$(jq -c . .notify-patterns.json)"
 
 print_info "> Creating D1 database"
 npx wrangler d1 create bankmandb
 # shellcheck disable=SC2034
-DATABASE_ID=$(npx wrangler d1 list | grep bankman | awk '{print $2}')
+DATABASE_ID=$(npx wrangler d1 list | grep bankmandb | awk '{print $2}')
 export DATABASE_ID
 
 print_info "> Creating wrangler.toml"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,3 +1,7 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
 NO_D1_WARNING=true
 export NO_D1_WARNING
 
@@ -9,6 +13,16 @@ export PURPLE="\033[1;35m"
 export CYAN="\033[1;36m"
 export GREY="\033[0;37m"
 export RESET="\033[m"
+
+check_wrangler() {
+    if ! npm exec --no -- wrangler --version &> /dev/null
+    then
+        # shellcheck disable=SC2016
+        print_error "wrangler could not be found. Did you run \`npm install\` ?"
+        print_error "Exiting."
+        exit 1
+    fi
+}
 
 check_command() {
     if ! command -v "$1" &> /dev/null

--- a/scripts/put-patterns.sh
+++ b/scripts/put-patterns.sh
@@ -18,4 +18,4 @@ fi
 # shellcheck disable=SC2034
 KV_ID=$(npx wrangler kv:namespace list | jq -r '.[] | select(.title == "bankman-KV") | .id')
 
-npx wrangler kv:key --namespace-id $KV_ID put 'transaction-matchers' "$(cat .notify-patterns.json | jq -c .)"
+npx wrangler kv:key --namespace-id "$KV_ID" put 'transaction-matchers' "$(jq -c . .notify-patterns.json)"

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euf -o pipefail
+
+source ./scripts/common.sh
+
+check_command jq
+check_command npx
+check_command envsubst
+check_command sed
+check_command tr
+check_command grep
+check_command awk
+
+check_wrangler
+
+KV_ID=$(npx wrangler kv:namespace list | jq -r '.[] | select(.title == "bankman-KV") | .id')
+
+if [ -z "$KV_ID" ]; then
+    print_info "> Skipping KV namespace deletion, no bankman-KV found"
+else
+    npx wrangler kv:namespace delete --namespace-id "$KV_ID"
+    print_success "> Deleted KB namespace bankman-KV ($KV_ID)"
+fi
+
+if ! npx wrangler d1 list | grep -q bankmandb ; then
+    print_info "> Skipping D1 database deletion, no bankmandb database found"
+else
+    npx wrangler d1 delete bankmandb
+    print_success "> Deleted D1 database bankmandb"
+fi
+
+npx wrangler delete bankman


### PR DESCRIPTION
This PR adds [`git-cliff`](https://git-cliff.org) for changelog automation.
We should investigate introducing some git hooks to generate the changelog before pushing or commiting.
In order to git-cliff to work, the commit messages should be compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Add a teardown script to delete KV namespace, database and worker.