### PR TITLE
fix: Handle Nordigen account status.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -359,11 +359,7 @@ async function doExecute(env: Env) {
 
 	const results = await fetchNordigenTransactions(token, env.NORDIGEN_ACCOUNT_ID, dateFrom, dateTo);
 
-<<<<<<< Updated upstream
-	console.log("booked", results.transactions.booked);
-=======
 	console.log("storing booked transactions:", results.transactions.booked);
->>>>>>> Stashed changes
 
 	// store transactions in DB
 	await storeBankTransactions(env.DB, results.transactions.booked);


### PR DESCRIPTION
* Checks current account status and halts if in ERROR or SUSPENDED (more regarding error and suspended status [here](https://nordigen.zendesk.com/hc/en-gb/articles/6760961247645?input_string=error+409+when+requesting+transactions))
* If status changed since last execution, then reports status change to discord.
* Adds more console logging since errors thrown in worker lack context.