### PR TITLE
Add scripts to help linking Nordigen account.

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -43,3 +43,11 @@ print_info() {
 print_success() {
     echo -e "${GREEN}$1${RESET}"
 }
+
+get_nordigen_token() {
+    curl -X POST "https://ob.nordigen.com/api/v2/token/new/" \
+  -H "accept: application/json" \
+  -H  "Content-Type: application/json" \
+  -d "{\"secret_id\":\"$1\", \"secret_key\":\"$2\"}" | \
+  jq .access -r
+}

--- a/scripts/nordigen-account-metadata.sh
+++ b/scripts/nordigen-account-metadata.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+usage() {
+    echo -e -n "Usage:\n$0\n"
+    echo ""
+    echo "This script returns the nordigen account metadata."
+    echo "Refer to https://nordigen.com/en/docs/account-information/integration/parameters-and-responses/#/accounts/retrieve%20account%20metadata for more details."
+}
+
+if [ $# -ne 0 ]
+then
+    usage
+    exit 1
+fi
+
+source ./scripts/common.sh
+
+export $(xargs < .dev.vars)
+
+TOKEN=$(get_nordigen_token $NORDIGEN_SECRET_ID $NORDIGEN_SECRET_KEY)
+
+curl -v -L -X GET "https://ob.nordigen.com/api/v2/accounts/$NORDIGEN_ACCOUNT_ID/" \
+  -H  "accept: application/json" \
+  -H  "Authorization: Bearer ${TOKEN}" | \
+  jq .

--- a/scripts/nordigen-link-account.sh
+++ b/scripts/nordigen-link-account.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+usage() {
+    echo -e -n "Usage:\n$0 <instituition-id> [reference]\n"
+    echo ""
+    echo "This script follows the quickstart at https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/."
+    echo "You can use the script at scripts/nordigen-list-institutions.sh to list the institutions available in your country."
+    echo "Use the id returned by that script as argument for this one."
+    echo ""
+    echo "Notes:"
+    echo "- No agreement is sent in the request (refer to quickstart link above for details)"
+    echo "- We set reference field with \"124151\" unless provided by env var REFERENCE."
+    echo "- User language is assumed to be EN"
+    echo "- After successful authorization you'll be redirected to http://localhost:3000/ as this allows you to listen on that port if you need to."
+    echo "- To change any of the fields mentioned above, our suggestion is to edit this very script."
+    echo ""
+    echo "Returns an object with a field 'link' that you must use to authorize your bank letting Nordigen access account transaction details."
+}
+
+if [ $# -lt 1 ]
+then
+    usage
+    exit 1
+fi
+
+source ./scripts/common.sh
+
+export $(xargs < .dev.vars)
+
+TOKEN=$(get_nordigen_token $NORDIGEN_SECRET_ID $NORDIGEN_SECRET_KEY)
+
+curl -X POST "https://ob.nordigen.com/api/v2/requisitions/" \
+  -H  "accept: application/json" -H  "Content-Type: application/json" \
+  -H  "Authorization: Bearer ${TOKEN}" \
+  -d "{\"redirect\": \"http://localhost:3000\",
+       \"institution_id\": \"$1\",
+       \"reference\": \"${REFERENCE:=124152}\",
+       \"user_language\":\"EN\" }" | \
+    jq .

--- a/scripts/nordigen-list-accounts.sh
+++ b/scripts/nordigen-list-accounts.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
-set -xeuf -o pipefail
+set -euf -o pipefail
 
 usage() {
     echo -e -n "Usage:\n$0 <requisition-id>\n"
     echo ""
     echo "This script lists accounts you've linked with Nordigen."
     echo "The requisition id is obtained from the link account procedure. More details in scripts/nordigen-link-account.sh."
-    echo "Refer to https://nordigen.com/en/account_information_documenation/
-    integration/quickstart_guide/ for more details."
+    echo "Refer to https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/ for more details."
 }
 
-if [ $# -lt 1 ]
+if [ $# -ne 1 ]
 then
     usage
     exit 1

--- a/scripts/nordigen-list-accounts.sh
+++ b/scripts/nordigen-list-accounts.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -xeuf -o pipefail
+
+usage() {
+    echo -e -n "Usage:\n$0 <requisition-id>\n"
+    echo ""
+    echo "This script lists accounts you've linked with Nordigen."
+    echo "The requisition id is obtained from the link account procedure. More details in scripts/nordigen-link-account.sh."
+    echo "Refer to https://nordigen.com/en/account_information_documenation/
+    integration/quickstart_guide/ for more details."
+}
+
+if [ $# -lt 1 ]
+then
+    usage
+    exit 1
+fi
+
+source ./scripts/common.sh
+
+export $(xargs < .dev.vars)
+
+TOKEN=$(get_nordigen_token $NORDIGEN_SECRET_ID $NORDIGEN_SECRET_KEY)
+
+curl -v -L -X GET "https://ob.nordigen.com/api/v2/requisitions/$1" \
+  -H  "accept: application/json" \
+  -H  "Authorization: Bearer ${TOKEN}" | \
+  jq .

--- a/scripts/nordigen-list-institutions.sh
+++ b/scripts/nordigen-list-institutions.sh
@@ -11,7 +11,7 @@ usage() {
     integration/quickstart_guide/ for more details."
 }
 
-if [ $# -lt 1 ]
+if [ $# -ne 1 ]
 then
     usage
     exit 1

--- a/scripts/nordigen-list-institutions.sh
+++ b/scripts/nordigen-list-institutions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+usage() {
+    echo -e -n "Usage:\n$0 <country-code>\n"
+    echo ""
+    echo "This script list banks available in Nordigen given a coutry ISO Code."
+    echo "Only id and name fields are printed."
+    echo "Refer to https://nordigen.com/en/account_information_documenation/
+    integration/quickstart_guide/ for more details."
+}
+
+if [ $# -lt 1 ]
+then
+    usage
+    exit 1
+fi
+
+source ./scripts/common.sh
+
+export $(xargs < .dev.vars)
+
+TOKEN=$(get_nordigen_token $NORDIGEN_SECRET_ID $NORDIGEN_SECRET_KEY)
+
+curl -X GET "https://ob.nordigen.com/api/v2/institutions/?country=$1" \
+  -H  "accept: application/json" \
+  -H  "Authorization: Bearer ${TOKEN}" | \
+  jq '.[] | {id:.id,name:.name}'


### PR DESCRIPTION
When ingressing for the first time and when renewing the agreement after expiration, we must do a few requests to the Nordigen APIs.
This PR includes scripts to:
* List Nordigen supported institutions by country code
* List Nordigen accounts
* Get Nordigen account metadata
* Link bank with a Nordigen account.

All these steps follow the quickstart guide: https://nordigen.com/en/account_information_documenation/integration/quickstart_guide/